### PR TITLE
Silence promauto metrics from Global registry

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -26,7 +26,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/gosnmp/gosnmp"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/prometheus/snmp_exporter/config"
@@ -38,14 +37,14 @@ const (
 
 var (
 	buckets               = prometheus.ExponentialBuckets(0.0001, 2, 15)
-	snmpUnexpectedPduType = promauto.NewCounter(
+	snmpUnexpectedPduType = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: namespace,
 			Name:      "unexpected_pdu_type_total",
 			Help:      "Unexpected Go types in a PDU.",
 		},
 	)
-	snmpDuration = promauto.NewHistogram(
+	snmpDuration = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: namespace,
 			Name:      "packet_duration_seconds",
@@ -53,14 +52,14 @@ var (
 			Buckets:   buckets,
 		},
 	)
-	snmpPackets = promauto.NewCounter(
+	snmpPackets = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: namespace,
 			Name:      "packets_total",
 			Help:      "Number of SNMP packet sent, including retries.",
 		},
 	)
-	snmpRetries = promauto.NewCounter(
+	snmpRetries = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: namespace,
 			Name:      "packet_retries_total",

--- a/main.go
+++ b/main.go
@@ -26,7 +26,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/common/promlog/flag"
@@ -47,14 +46,14 @@ var (
 	dryRun        = kingpin.Flag("dry-run", "Only verify configuration is valid and exit.").Default("false").Bool()
 
 	// Metrics about the SNMP exporter itself.
-	snmpDuration = promauto.NewSummaryVec(
+	snmpDuration = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Name: "snmp_collection_duration_seconds",
 			Help: "Duration of collections by the SNMP exporter",
 		},
 		[]string{"module"},
 	)
-	snmpRequestErrors = promauto.NewCounter(
+	snmpRequestErrors = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "snmp_request_errors_total",
 			Help: "Errors in requests to the SNMP exporter",


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalis.tsilias@grafana.com>

This is for the first iteration of the SNMP integration in https://github.com/grafana/agent/pull/1364. We would like to avoid these metrics to the Global registry and the root /metrics.

Regarding the v1 SNMP integration cannot have a second endpoint, so there's no great way of presenting these internal metrics.

Regarding the v2 SNMP integration, we could add these 'internal' metrics back in a future improvement PR, exposed on a different endpoint. One solution would be to pass a `prometheus.Registerer` in our constructor, and use that to register those metrics.

Let me know if you think this is an acceptable solution as an MVP :) 